### PR TITLE
Feature/api endpoints

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -18,7 +18,7 @@ version = "4.10.0"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1"},
     {file = "anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6"},
@@ -94,6 +94,18 @@ colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.10)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "certifi"
+version = "2025.8.3"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5"},
+    {file = "certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407"},
+]
 
 [[package]]
 name = "cffi"
@@ -577,11 +589,58 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.16"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "identify"
@@ -604,7 +663,7 @@ version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -1552,7 +1611,7 @@ version = "1.3.1"
 description = "Sniff out which async library your code is running under"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
@@ -1819,4 +1878,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "bf08dd6554a98e45ac0efb4afb5bfac51fbdd228b1a79951ddc51607f930edac"
+content-hash = "fb9aeb9a213729765c2a02ec7534d3d6bd30b51eeda24369f9ccc0b7c11c4fad"

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,6 +13,27 @@ files = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.10.0"
+description = "High-level concurrency and networking framework on top of asyncio or Trio"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1"},
+    {file = "anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6"},
+]
+
+[package.dependencies]
+exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
+
+[package.extras]
+trio = ["trio (>=0.26.1)"]
+
+[[package]]
 name = "argcomplete"
 version = "3.6.2"
 description = "Bash tab completion for argparse"
@@ -504,7 +525,7 @@ version = "1.3.0"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10"},
     {file = "exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88"},
@@ -517,6 +538,28 @@ typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "fastapi"
+version = "0.116.1"
+description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "fastapi-0.116.1-py3-none-any.whl", hash = "sha256:c46ac7c312df840f0c9e220f7964bada936781bc4e2e6eb71f1c4d7553786565"},
+    {file = "fastapi-0.116.1.tar.gz", hash = "sha256:ed52cbf946abfd70c5a0dccb24673f0670deeb517a88b3544d03c2a6bf283143"},
+]
+
+[package.dependencies]
+pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
+starlette = ">=0.40.0,<0.48.0"
+typing-extensions = ">=4.8.0"
+
+[package.extras]
+all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+
+[[package]]
 name = "filelock"
 version = "3.19.1"
 description = "A platform independent file lock."
@@ -526,6 +569,18 @@ groups = ["dev"]
 files = [
     {file = "filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d"},
     {file = "filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58"},
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
 
 [[package]]
@@ -542,6 +597,21 @@ files = [
 
 [package.extras]
 license = ["ukkonen"]
+
+[[package]]
+name = "idna"
+version = "3.10"
+description = "Internationalized Domain Names in Applications (IDNA)"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
+    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
+]
+
+[package.extras]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "importlib-metadata"
@@ -1327,6 +1397,18 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.20"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104"},
+    {file = "python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 description = "YAML parser and emitter for Python"
@@ -1463,6 +1545,37 @@ files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
 ]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
+name = "starlette"
+version = "0.47.3"
+description = "The little ASGI library that shines."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "starlette-0.47.3-py3-none-any.whl", hash = "sha256:89c0778ca62a76b826101e7c709e70680a1699ca7da6b44d38eb0a7e61fe4b51"},
+    {file = "starlette-0.47.3.tar.gz", hash = "sha256:6bc94f839cc176c4858894f1f8908f0ab79dfec1a6b8402f6da9be26ebea52e9"},
+]
+
+[package.dependencies]
+anyio = ">=3.6.2,<5"
+typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""}
+
+[package.extras]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "tenacity"
@@ -1630,6 +1743,26 @@ files = [
 ]
 
 [[package]]
+name = "uvicorn"
+version = "0.35.0"
+description = "The lightning-fast ASGI server."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a"},
+    {file = "uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01"},
+]
+
+[package.dependencies]
+click = ">=7.0"
+h11 = ">=0.8"
+typing-extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.13)", "websockets (>=10.4)"]
+
+[[package]]
 name = "virtualenv"
 version = "20.34.0"
 description = "Virtual Python Environment builder"
@@ -1686,4 +1819,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "79d69357d0ac88a2239e27da26deb58c3d4f09334e734dafe8ff5eb200eee6db"
+content-hash = "bf08dd6554a98e45ac0efb4afb5bfac51fbdd228b1a79951ddc51607f930edac"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ tenacity = ">=9.1.2,<10.0.0"
 pillow = ">=11.3.0,<12.0.0"
 pytesseract = ">=0.3.13,<0.4.0"
 tzdata = "^2025.2"
+fastapi = "^0.116.1"
+uvicorn = "^0.35.0"
+python-multipart = "^0.0.20"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.12.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ pytest-cov = "^6.2.1"
 pre-commit = "^4.3.0"
 commitizen = "^4.8.3"
 exceptiongroup = "^1.2.1"
+httpx = "^0.28.1"
 
 [tool.poetry.scripts]
 ws-docflow = "ws_docflow.cli.app:app"

--- a/src/ws_docflow/api/main.py
+++ b/src/ws_docflow/api/main.py
@@ -1,0 +1,135 @@
+# src/ws_docflow/api/main.py
+from __future__ import annotations
+
+import base64
+import os
+import tempfile
+from typing import Optional
+
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, field_validator
+
+from ws_docflow.infra.pdf.pdfplumber_extractor import PdfPlumberExtractor
+from ws_docflow.infra.parsers.br_dta_parser import BrDtaParser
+from ws_docflow.infra.parsers.br_dta_extrato_parser import BrDtaExtratoParser
+from ws_docflow.core.use_cases.extract_data import ExtractDataUseCase
+
+app = FastAPI(title="ws-docflow API", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+# -------- modelos para base64 --------
+class ParseBase64Request(BaseModel):
+    filename: Optional[str] = "documento.pdf"
+    content_base64: str  # PDF em base64 (sem data URI)
+
+    @field_validator("content_base64")
+    @classmethod
+    def must_be_base64(cls, v: str) -> str:
+        try:
+            base64.b64decode(v, validate=True)
+        except Exception as exc:
+            raise ValueError(f"content_base64 inválido: {exc}")
+        return v
+
+
+def _parse_with_single(source: str | bytes, parser) -> dict:
+    extractor = PdfPlumberExtractor()
+    uc = ExtractDataUseCase(extractor, parser)
+    doc = uc.run(source)
+    return doc.model_dump(mode="json", exclude_none=True, exclude_unset=True)
+
+
+def _parse_with_uc(source: str | bytes) -> dict:
+    """
+    Tenta sequencialmente os parsers:
+      1) BrDtaExtratoParser (extrato)
+      2) BrDtaParser        (DTA comum)
+    Cai para o próximo parser se o atual não casar.
+    """
+    last_err: Exception | None = None
+    for parser_cls in (BrDtaExtratoParser, BrDtaParser):
+        try:
+            return _parse_with_single(source, parser_cls())
+        except Exception as exc:
+            last_err = exc
+            # segue tentando o próximo parser
+            continue
+    # se nenhum parser casou, propaga o último erro
+    raise (
+        last_err
+        if last_err
+        else HTTPException(status_code=422, detail="Falha ao processar PDF.")
+    )
+
+
+def _run_parse_from_bytes(pdf_bytes: bytes) -> dict:
+    if not pdf_bytes:
+        raise HTTPException(status_code=400, detail="Arquivo vazio.")
+    if not pdf_bytes.startswith(b"%PDF"):
+        trimmed = pdf_bytes.lstrip()
+        if not trimmed.startswith(b"%PDF"):
+            raise HTTPException(
+                status_code=415, detail="Conteúdo não parece ser um PDF válido."
+            )
+
+    # 1) Tenta abrir direto por bytes (se extractor aceitar bytes)
+    try:
+        return _parse_with_uc(pdf_bytes)
+    except TypeError:
+        pass
+
+    # 2) Fallback Windows-safe: temp file delete=False + cleanup
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp.write(pdf_bytes)
+            tmp_path = tmp.name
+        return _parse_with_uc(tmp_path)
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except Exception:
+                pass
+
+
+# -------- endpoint multipart (mantido) --------
+@app.post("/api/parse")
+async def parse_pdf(file: UploadFile = File(...)):
+    if file.content_type not in ("application/pdf", "application/octet-stream"):
+        raise HTTPException(
+            status_code=415, detail="Envie um arquivo PDF válido (application/pdf)."
+        )
+    try:
+        content = await file.read()
+        data = _run_parse_from_bytes(content)
+        return JSONResponse(content=data)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail=f"Falha ao processar PDF: {exc}")
+
+
+# -------- novo endpoint JSON com base64 --------
+@app.post("/api/parse-b64")
+def parse_pdf_base64(payload: ParseBase64Request):
+    try:
+        pdf_bytes = base64.b64decode(payload.content_base64, validate=True)
+        data = _run_parse_from_bytes(pdf_bytes)
+        return JSONResponse(content=data)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(
+            status_code=422, detail=f"Falha ao processar PDF (base64): {exc}"
+        )

--- a/src/ws_docflow/core/ports.py
+++ b/src/ws_docflow/core/ports.py
@@ -1,8 +1,11 @@
-from typing import Protocol
+from typing import Protocol, Union
+
+
+SourceT = Union[str, bytes]
 
 
 class TextExtractor(Protocol):
-    def extract(self, pdf_path: str) -> str: ...
+    def extract(self, source: SourceT) -> str: ...
 
 
 class DocParser(Protocol):

--- a/src/ws_docflow/core/ports.py
+++ b/src/ws_docflow/core/ports.py
@@ -1,7 +1,19 @@
-from typing import Protocol, Union
+from __future__ import annotations
 
+from typing import Protocol, Union, runtime_checkable, Dict, Any
 
 SourceT = Union[str, bytes]
+
+
+@runtime_checkable
+class DocModel(Protocol):
+    def model_dump(
+        self,
+        *,
+        mode: str = "json",
+        exclude_none: bool = True,
+        exclude_unset: bool = True,
+    ) -> Dict[str, Any]: ...
 
 
 class TextExtractor(Protocol):
@@ -9,4 +21,4 @@ class TextExtractor(Protocol):
 
 
 class DocParser(Protocol):
-    def parse(self, text: str): ...
+    def parse(self, text: str) -> DocModel: ...

--- a/src/ws_docflow/core/use_cases/extract_data.py
+++ b/src/ws_docflow/core/use_cases/extract_data.py
@@ -1,9 +1,8 @@
-# src/ws_docflow/core/use_cases/extract_data.py
 from __future__ import annotations
 
-from typing import Iterable, List, Sequence, Union
+from typing import Iterable, List, Sequence, Union, Optional
 
-from ws_docflow.core.ports import TextExtractor, DocParser
+from ws_docflow.core.ports import TextExtractor, DocParser, DocModel
 
 SourceT = Union[str, bytes]
 
@@ -11,7 +10,7 @@ SourceT = Union[str, bytes]
 class ExtractDataUseCase:
     """
     Orquestra a extração de texto e o parsing.
-    Agora aceita um único parser OU uma sequência de parsers, tentando em fallback.
+    Aceita um único parser OU uma sequência de parsers (fallback).
     """
 
     def __init__(
@@ -24,25 +23,21 @@ class ExtractDataUseCase:
         if isinstance(parser_or_parsers, Iterable) and not isinstance(
             parser_or_parsers, (str, bytes)
         ):
-            self.parsers: List[DocParser] = list(
-                parser_or_parsers
-            )  # já é sequência de parsers
+            self.parsers: List[DocParser] = list(parser_or_parsers)
         else:
             self.parsers = [parser_or_parsers]  # um único parser
 
-    def run(self, source: SourceT) -> any:
-        text = self.extractor.extract(source)  # mantém igual
-        last_err: Exception | None = None
+    def run(self, source: SourceT) -> DocModel:
+        text = self.extractor.extract(source)
+        last_err: Optional[Exception] = None
 
         for parser in self.parsers:
             try:
                 return parser.parse(text)
             except Exception as exc:
-                # guarda e tenta o próximo parser
                 last_err = exc
                 continue
 
-        # se nenhum parser conseguiu, propaga o último erro para facilitar o debug
         if last_err:
             raise last_err
         raise RuntimeError("Nenhum parser configurado.")

--- a/src/ws_docflow/core/use_cases/extract_data.py
+++ b/src/ws_docflow/core/use_cases/extract_data.py
@@ -5,6 +5,8 @@ from typing import Iterable, List, Sequence, Union
 
 from ws_docflow.core.ports import TextExtractor, DocParser
 
+SourceT = Union[str, bytes]
+
 
 class ExtractDataUseCase:
     """
@@ -28,8 +30,8 @@ class ExtractDataUseCase:
         else:
             self.parsers = [parser_or_parsers]  # um único parser
 
-    def run(self, pdf_path: str):
-        text = self.extractor.extract(pdf_path)  # mantém igual
+    def run(self, source: SourceT) -> any:
+        text = self.extractor.extract(source)  # mantém igual
         last_err: Exception | None = None
 
         for parser in self.parsers:

--- a/src/ws_docflow/infra/parsers/br_dta_extrato_parser.py
+++ b/src/ws_docflow/infra/parsers/br_dta_extrato_parser.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from datetime import datetime
 from decimal import Decimal
-from typing import Dict, Optional
+from typing import Dict, Literal, Optional
 
 from zoneinfo import ZoneInfo
 
@@ -21,6 +21,8 @@ from ws_docflow.core.domain.models import (
 )
 
 TZ = ZoneInfo("America/Sao_Paulo")
+
+TipoTotais = Literal["ARMAZENAMENTO", "OUTRO", "DESCONHECIDO"]
 
 # -----------------------
 # Utilidades / helpers
@@ -254,6 +256,15 @@ class BrDtaExtratoParser(DocParser):
                     return "DESCONHECIDO"
                 return "OUTRO"
 
+            def _norm_tipo_totais(v: str | None) -> TipoTotais:
+                if not v:
+                    return "DESCONHECIDO"
+                s = v.strip().upper()
+                if "ARMAZEN" in s:  # cobre 'ARMAZENAMENTO'
+                    return "ARMAZENAMENTO"
+                # adicione outros padrões se surgirem layouts distintos
+                return "OUTRO"
+
             usd = brl = None
             try:
                 usd = parse_money_ptbr(t.group("usd"))
@@ -262,7 +273,7 @@ class BrDtaExtratoParser(DocParser):
                 pass
 
             doc.totais_origem = TotaisOrigem(
-                tipo=_normalize_tipo(tipo_raw),
+                tipo=_norm_tipo_totais(tipo_raw),
                 valor_total_usd=usd,
                 valor_total_brl=brl,
             )

--- a/src/ws_docflow/infra/pdf/pdfplumber_extractor.py
+++ b/src/ws_docflow/infra/pdf/pdfplumber_extractor.py
@@ -1,14 +1,36 @@
 # src/ws_docflow/infra/pdf/pdfplumber_extractor.py
+from __future__ import annotations
+
+import io
+from typing import Union
+
 import pdfplumber
 from ws_docflow.core.ports import TextExtractor
 
 
 class PdfPlumberExtractor(TextExtractor):
-    def extract(self, pdf_path: str) -> str:
+    def extract(self, source: Union[str, bytes]) -> str:
+        """
+        Extrai texto de um PDF a partir de:
+          - caminho de arquivo (str)
+          - conteúdo bruto em bytes
+        """
         parts: list[str] = []
-        with pdfplumber.open(pdf_path) as pdf:
+
+        if isinstance(source, bytes):
+            pdf_stream = io.BytesIO(source)
+            pdf = pdfplumber.open(pdf_stream)
+        elif isinstance(source, str):
+            pdf = pdfplumber.open(source)
+        else:
+            raise TypeError(
+                f"Tipo de entrada inválido para PdfPlumberExtractor: {type(source)}"
+            )
+
+        with pdf:
             for page in pdf.pages:
-                t = page.extract_text() or ""
-                if t:
-                    parts.append(t)
+                text = page.extract_text() or ""
+                if text:
+                    parts.append(text)
+
         return "\n".join(parts).strip()

--- a/src/ws_docflow/infra/pdf/pdfplumber_extractor.py
+++ b/src/ws_docflow/infra/pdf/pdfplumber_extractor.py
@@ -7,9 +7,11 @@ from typing import Union
 import pdfplumber
 from ws_docflow.core.ports import TextExtractor
 
+SourceT = Union[str, bytes]
+
 
 class PdfPlumberExtractor(TextExtractor):
-    def extract(self, source: Union[str, bytes]) -> str:
+    def extract(self, source: SourceT) -> str:
         """
         Extrai texto de um PDF a partir de:
           - caminho de arquivo (str)

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -1,0 +1,146 @@
+# tests/api/test_main.py
+from __future__ import annotations
+
+import base64
+from typing import Any, Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+import ws_docflow.api.main as api_main
+
+
+class FakeDoc:
+    """Objeto fake para simular retorno do use case (Pydantic-like)."""
+
+    def __init__(self, payload: Dict[str, Any]):
+        self._payload = payload
+
+    def model_dump(
+        self, mode: str = "json", exclude_none: bool = True, exclude_unset: bool = True
+    ):
+        return self._payload
+
+
+class FakeUC:
+    """Substitui ExtractDataUseCase dentro do módulo da API."""
+
+    def __init__(self, extractor, parsers):
+        # podemos inspecionar/guardar se necessário
+        self.extractor = extractor
+        self.parsers = parsers
+
+    def run(self, source: str | bytes):
+        # Apenas valida se o "PDF" começa com %PDF (tolerando espaços antes),
+        # que é a mesma checagem feita no main._run_parse_from_bytes.
+        if isinstance(source, (bytes, bytearray)):
+            data = bytes(source)
+        elif isinstance(source, str):
+            # quando cair no fallback via arquivo temporário, o main abre por caminho;
+            # aqui não vamos reler o arquivo; apenas devolvemos algo estático de sucesso.
+            data = b"%PDF from path"
+        else:
+            raise TypeError("source inválido no FakeUC.run")
+
+        # Tolerar espaços/brancos antes do header
+        if not (data.startswith(b"%PDF") or data.lstrip().startswith(b"%PDF")):
+            raise ValueError("Conteúdo não parece PDF no FakeUC")
+
+        # Simula payload do parser (campos exemplo do projeto)
+        payload = {
+            "origem": {
+                "unidade_local": {
+                    "codigo": "1017700",
+                    "descricao": "PORTO DE RIO GRANDE",
+                },
+                "recinto_aduaneiro": {
+                    "codigo": "0301304",
+                    "descricao": "TECON RIO GRANDE",
+                },
+            },
+            "destino": {
+                "unidade_local": {
+                    "codigo": "1010700",
+                    "descricao": "DRF NOVO HAMBURGO",
+                },
+                "recinto_aduaneiro": {
+                    "codigo": "0403201",
+                    "descricao": "EADI MULTI ARMAZENS",
+                },
+            },
+            "beneficiario": {
+                "documento": "08.325.039/0001-90",
+                "nome": "SS INDUSTRIA METALURGICA DE TELAS LTDA",
+            },
+            "transportador": {
+                "documento": "13.233.554/0001-80",
+                "nome": "MULTI EXPRESS BRASIL TRANSPORTES DE CARGAS LTDA",
+            },
+            "totais_origem": {
+                "tipo": "ARMAZENAMENTO",
+                "valor_total_usd": 57024.00,
+                "valor_total_brl": 308585.37,
+            },
+        }
+        return FakeDoc(payload)
+
+
+@pytest.fixture(autouse=True)
+def patch_use_case(monkeypatch):
+    """
+    Substitui ExtractDataUseCase no módulo da API por FakeUC
+    para tornar os testes determinísticos e independentes do pdfplumber.
+    """
+    monkeypatch.setattr(api_main, "ExtractDataUseCase", FakeUC)
+    yield
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(api_main.app)
+
+
+def test_parse_b64_ok(client: TestClient):
+    # PDF bytes com espaços antes do header (para cobrir a tolerância do main)
+    pdf_bytes = b"   %PDF-1.7\n%Mock PDF content for tests\n"
+    payload = {
+        "filename": "teste.pdf",
+        "content_base64": base64.b64encode(pdf_bytes).decode("utf-8"),
+    }
+    resp = client.post("/api/parse-b64", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "origem" in data and "destino" in data
+    assert data["origem"]["unidade_local"]["codigo"] == "1017700"
+
+
+def test_parse_ok_multipart(client: TestClient):
+    pdf_bytes = b"%PDF-1.4\n%Mock PDF content\n"
+    files = {"file": ("arquivo.pdf", pdf_bytes, "application/pdf")}
+    resp = client.post("/api/parse", files=files)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "beneficiario" in data and "transportador" in data
+    assert data["totais_origem"]["valor_total_usd"] == 57024.00
+
+
+def test_parse_b64_invalido(client: TestClient):
+    # base64 inválido (caracteres fora do alfabeto)
+    payload = {"content_base64": "###nao-e-base64###"}
+    resp = client.post("/api/parse-b64", json=payload)
+    # Pydantic deve retornar 422 de validação
+    assert resp.status_code == 422
+    msg = resp.text.lower()
+    assert "content_base64" in msg
+
+
+def test_parse_nao_pdf_bytes(client: TestClient):
+    # bytes que não começam (nem após strip) com %PDF
+    pdf_like = b"NOT_A_PDF"
+    files = {"file": ("arquivo.pdf", pdf_like, "application/pdf")}
+    resp = client.post("/api/parse", files=files)
+    assert resp.status_code == 415
+    assert (
+        "pdf válido" in resp.text.lower()
+        or "conteúdo não parece ser um pdf válido" in resp.text.lower()
+    )


### PR DESCRIPTION
## ✨ O que foi feito
- Implementados endpoints da API FastAPI:
  - `POST /api/parse` (upload de arquivo PDF via multipart/form-data)
  - `POST /api/parse-b64` (upload de PDF em base64 via JSON)
- Fallback Extrato → Clássico ajustado também na API (mesma lógica da CLI).
- Adicionados testes unitários para ambos endpoints (FastAPI TestClient).
- Atualizado README.md com instruções de uso da API REST e confirmação do CI.

## ✅ Como testar
1. Subir o servidor:
   ```bash
   poetry run uvicorn ws_docflow.api.main:app --reload --port 8000
